### PR TITLE
Comment out initial run for Winetricks after installation

### DIFF
--- a/debian-install-3-apps-or-no-nvidia.sh
+++ b/debian-install-3-apps-or-no-nvidia.sh
@@ -135,8 +135,9 @@ winecfg
 # install the add-on for winecfg when prompted
 # when the main winecfg screen appears, just select the type of Windows (Windows 10) and hit OK to continue for now
 sudo apt-get -y install winetricks
+# Commented out running winetricks, because no need... was originally done prior to installing allfonts, but right now that gets 404 errors so a pre-run isn't needed.
+#winetricks
 # just cancel out when WineTricks loads
-winetricks
 #!winetricks allfonts (getting 404 errors)
 
 # Steam


### PR DESCRIPTION
Originally was run prior to also installing allfonts via winetricks, but at present time that allfonts line is returning a 404 error, so no need for a pre-run at this time.